### PR TITLE
Update Azure.Identity from 1.10.4 with CVE to patched version 1.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="Common">
-    <PackageVersion Include="Azure.Identity" Version="1.10.4" />
+    <PackageVersion Include="Azure.Identity" Version="1.11.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageVersion Include="DotNetEnv" Version="3.0.0" />


### PR DESCRIPTION
The bvt pipeline was failing due to a warning as error for a known vulnerability in the Azure Identity library:

https://github.com/advisories/GHSA-wvxc-855f-jvrv

I have now updated the version.