### PR TITLE
fix: performance of terminology server tests

### DIFF
--- a/tests/Unit.Tests/Infrastructure/Terminology/FileTerminologyServiceTests.cs
+++ b/tests/Unit.Tests/Infrastructure/Terminology/FileTerminologyServiceTests.cs
@@ -9,48 +9,36 @@ public class FileTerminologyServiceTests
     [Fact]
     public void GetSnomedDisplay_ShouldReturnSnomedDescription_WhenCodeIsInCache()
     {
-        var memoryCache = Substitute.For<IMemoryCache>();
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
         var logger = Substitute.For<ILogger<FileTerminologyService>>();
-
-        var anyStringArg = Arg.Any<string>();
-        memoryCache.TryGetValue("123", out anyStringArg).Returns(x =>
-        {
-            x[1] = "Example code display";
-            return true;
-        });
+        memoryCache.Set("22298006", "Myocardial infarction (disorder)");
 
         var terminologyService = new FileTerminologyService(memoryCache, logger);
 
-        var result = terminologyService.GetSnomedDisplay("123");
-        result.ShouldBe("Example code display");
+        var result = terminologyService.GetSnomedDisplay("22298006");
+        result.ShouldBe("Myocardial infarction (disorder)");
     }
 
     [Fact]
     public void GetSnomedDisplay_ShouldReturnEmptyString_WhenCodeIsNotInCache()
     {
-        var memoryCache = Substitute.For<IMemoryCache>();
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
         var logger = Substitute.For<ILogger<FileTerminologyService>>();
-
-        var anyStringArg = Arg.Any<string>();
-        memoryCache.TryGetValue("123", out anyStringArg).Returns(false);
 
         var terminologyService = new FileTerminologyService(memoryCache, logger);
 
-        var result = terminologyService.GetSnomedDisplay("123");
+        var result = terminologyService.GetSnomedDisplay("12345678");
         result.ShouldBe(string.Empty);
     }
 
     [Fact]
     public void GetSnomedDisplay_ShouldLogWarning_WhenCodeIsNotInCache()
     {
-        var memoryCache = Substitute.For<IMemoryCache>();
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
         var logger = Substitute.For<ILogger<FileTerminologyService>>();
 
-        var anyStringArg = Arg.Any<string>();
-        memoryCache.TryGetValue("123", out anyStringArg).Returns(false);
-
         var terminologyService = new FileTerminologyService(memoryCache, logger);
-        var result = terminologyService.GetSnomedDisplay("123");
+        var result = terminologyService.GetSnomedDisplay("12345678");
 
         logger.Received(1).AnyLogOfType(LogLevel.Warning);
     }


### PR DESCRIPTION
In the Dorset downstream project, the Unit Tests fail to execute in a timely fashion. This is due to the `IMemoryCache` mock - and it's poor performance when the Snomed codes are populated.

This PR replaces the unnecessary mock, and uses a newly instantiated `MemoryCache` for each test execution.

With a full Snomed dataset, the Unit Tests now complete in a more reasonable time window. As seen here:

<img width="435" alt="image" src="https://github.com/dorset-ics/healthcare-data-exchange/assets/2767292/49fe0f3b-a0be-4dfe-968c-83b58ee9bd0e">

**Note:** I have also updated the test to use a Snomed code from an example provided in this [NHS article](https://www.england.nhs.uk/long-read/clinical-coding-snomed-ct/).