### PR TITLE
Add GET "/" route to avoid error logging from AppService AlwaysOn agent.

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -25,6 +25,7 @@ app.UseExceptionHandler();
 app.UseHttpsRedirection();
 app.UseCors("DexCorsPolicy");
 app.MapHealthChecks("/_health", new HealthCheckOptions { ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse });
+app.MapGet("/", () => "Welcome to Healthcare Data Exchange. Please refer to the documentation for detailed usage guidelines.");
 app.MapCarter();
 
 if (app.Environment.IsEnvironment("Local"))


### PR DESCRIPTION
Added a home root route to not throw an error from AppService AlwaysOn daemon.
Tested the home route manually using Postman.


![SCR-20240415-kzor](https://github.com/dorset-ics/healthcare-data-exchange/assets/4739534/cc064478-cafd-4b9f-bb3f-c595fdf47d38)





