### PR TITLE
fix: use Utc in OdsServiceTests

### DIFF
--- a/tests/Integration.Tests/Core/Ods/OdsServiceTests.cs
+++ b/tests/Integration.Tests/Core/Ods/OdsServiceTests.cs
@@ -31,7 +31,7 @@ public class OdsServiceTests : IDisposable
     [Fact]
     public async Task GivenValidOdsDownloadSource_WhenIngestingCsvDownload_ThenResultIsSuccessful()
     {
-        var dateIngestStarted = DateTime.Now;
+        var dateIngestStarted = DateTime.UtcNow;
 
         // The complete CSV ingest currently takes a long time and this test can take 25 mins to complete.
         // So run it in a task, iterate for a maximum amount of time, query the fhir store at intervals, and
@@ -43,7 +43,7 @@ public class OdsServiceTests : IDisposable
 
         Bundle? bundle = null;
 
-        while (DateTime.Now <= dateIngestStarted.AddSeconds(60))
+        while (DateTime.UtcNow <= dateIngestStarted.AddSeconds(60))
         {
             bundle =
                 await _dataHubFhirClientWrapper.SearchResourceByParams<Organization>(


### PR DESCRIPTION
In `OdsServiceTests` we check to see if records have been created since the test execution time.

However, this was done using local time. The FHIR server uses UTC for the updated date. As such, in local environements using BST the tests were failing. 

This PR updates the test to use UTC.