### PR TITLE
fix: use Fhir Http client to hard delete patients

### DIFF
--- a/tests/Integration.Tests/Core/Pds/PdsServiceTests.cs
+++ b/tests/Integration.Tests/Core/Pds/PdsServiceTests.cs
@@ -22,12 +22,16 @@ public class PdsServiceTests : IDisposable
 {
     private readonly ApiWebApplicationFactory _webApplicationFactory;
     private readonly IPdsService _sut;
+    private readonly HttpClient _fhirHttpClient;
     private readonly IDataHubFhirClientWrapper _dataHubFhirClientWrapper;
 
     public PdsServiceTests()
     {
         _webApplicationFactory = new ApiWebApplicationFactory();
         _dataHubFhirClientWrapper = _webApplicationFactory.Services.GetService<IDataHubFhirClientWrapper>()!;
+        _fhirHttpClient = _webApplicationFactory.Services
+            .GetRequiredService<IHttpClientFactory>()
+            .CreateClient("DataHubFhirClient");
         _sut = _webApplicationFactory.Services.GetService<IPdsService>()
                ?? throw new Exception("Failed to resolve IPdsService from the service provider");
     }
@@ -227,14 +231,15 @@ public class PdsServiceTests : IDisposable
 
     private async Task CleanFhirStore()
     {
-        var searchResult =
-            await _dataHubFhirClientWrapper.SearchResourceByParams<Patient>(
-                new SearchParams().LimitTo(Globals.FhirServerMaxPageSize));
+        var searchParams = new SearchParams().LimitTo(Globals.FhirServerMaxPageSize);
+        var searchResult = await _dataHubFhirClientWrapper.SearchResourceByParams<Patient>(searchParams);
 
         while (searchResult != null)
         {
             foreach (var patient in searchResult.Entry)
-                await _dataHubFhirClientWrapper.DeleteAsync($"{patient.Resource.TypeName}/{patient.Resource.Id}");
+            {
+                await _fhirHttpClient.DeleteAsync($"Patient/{patient.Resource.Id}?hardDelete=true");
+            }
 
             searchResult = await _dataHubFhirClientWrapper.ContinueAsync(searchResult!);
 


### PR DESCRIPTION
`PdsServiceTests` has a method which deletes `Patient` resources from the Fhir Service. By default, this operation is a soft delete. 

The remaining "soft" copy of the resource prevents subsequent tests from running successfully - due to the 410 GONE Http result.

This PR updates the `CleanFhirStore` to "hard" delete the resource, using the `hardDelete` query parameters:

`Patient/9000000025?hardDelete=true`

Subsequent requests for "9000000025" will now result in a 404:

<img width="625" alt="image" src="https://github.com/dorset-ics/healthcare-data-exchange/assets/2767292/28dbc1df-f3b4-47a1-acca-431d825f8d2b">

> **NOTE:** This only affects the `Integration.Tests` project.



