### PR TITLE
Disable auto trigger on PR pipeline

### DIFF
--- a/.github/workflows/pr-pipeline.yaml
+++ b/.github/workflows/pr-pipeline.yaml
@@ -1,9 +1,10 @@
 name: PR
 
 on:
-    pull_request:
-        branches:
-            - main
+    # pull_request:
+    #     branches:
+    #         - main
+    workflow_dispatch:
         
 jobs:
     bvt:


### PR DESCRIPTION
Temporarily disable automatic triggering of the PR pipeline as the private repo has limited build resource.

- [ ] Tests
- [ ] Documentation
