### PR TITLE
fix: add name for index route

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -25,7 +25,7 @@ app.UseExceptionHandler();
 app.UseHttpsRedirection();
 app.UseCors("DexCorsPolicy");
 app.MapHealthChecks("/_health", new HealthCheckOptions { ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse });
-app.MapGet("/", () => "Welcome to Healthcare Data Exchange. Please refer to the documentation for detailed usage guidelines.");
+app.MapGet("/", () => "Welcome to Healthcare Data Exchange. Please refer to the documentation for detailed usage guidelines.").WithName("GetIndex");
 app.MapCarter();
 
 if (app.Environment.IsEnvironment("Local"))


### PR DESCRIPTION
The index route does not have a name:

![image](https://github.com/dorset-ics/healthcare-data-exchange/assets/2767292/f3e6e896-aad2-41ef-abde-6b634c85094a)

This breaks the deployment pipeline, as the operation Id is required.

This PR adds a name to the operation, which is used in the swagger generation.