### PR TITLE
fix: use managed identity from APIM to Fhir

### DIFF
--- a/infrastructure/health-services/role-assignment.tf
+++ b/infrastructure/health-services/role-assignment.tf
@@ -1,5 +1,11 @@
-resource "azurerm_role_assignment" "fhir_reader_role_assignment" {
+resource "azurerm_role_assignment" "fhir_reader_role_assignment_web_app" {
   principal_id         = var.web_app_system_assigned_identity
+  role_definition_name = "FHIR Data Contributor"
+  scope                = azurerm_healthcare_fhir_service.fhir.id
+}
+
+resource "azurerm_role_assignment" "fhir_reader_role_assignment_apim" {
+  principal_id         = var.api_management_system_assigned_identity
   role_definition_name = "FHIR Data Contributor"
   scope                = azurerm_healthcare_fhir_service.fhir.id
 }

--- a/infrastructure/health-services/variables.tf
+++ b/infrastructure/health-services/variables.tf
@@ -6,4 +6,5 @@ variable "health_zone_id" {}
 variable "tenant_id" {}
 variable "log_analytics_workspace_id" {}
 variable "web_app_system_assigned_identity" {}
+variable "api_management_system_assigned_identity" {}
 variable "oci_artifact_login_server" {}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -76,14 +76,15 @@ module "services" {
 }
 
 module "health-services" {
-  source                           = "./health-services"
-  location                         = var.location
-  resource_group_name              = azurerm_resource_group.rg.name
-  services_subnet_id               = module.network.services_subnet_id
-  env                              = var.env
-  health_zone_id                   = module.network.health_dns_zone_id
-  tenant_id                        = data.azurerm_client_config.current.tenant_id
-  log_analytics_workspace_id       = module.services.log_analytics_workspace_id
-  web_app_system_assigned_identity = module.services.web_app_system_assigned_identity
-  oci_artifact_login_server        = azurerm_container_registry.acr.login_server
+  source                                  = "./health-services"
+  location                                = var.location
+  resource_group_name                     = azurerm_resource_group.rg.name
+  services_subnet_id                      = module.network.services_subnet_id
+  env                                     = var.env
+  health_zone_id                          = module.network.health_dns_zone_id
+  tenant_id                               = data.azurerm_client_config.current.tenant_id
+  log_analytics_workspace_id              = module.services.log_analytics_workspace_id
+  web_app_system_assigned_identity        = module.services.web_app_system_assigned_identity
+  api_management_system_assigned_identity = module.services.api_management_system_assigned_identity
+  oci_artifact_login_server               = azurerm_container_registry.acr.login_server
 }

--- a/infrastructure/services/api_management/locals.tf
+++ b/infrastructure/services/api_management/locals.tf
@@ -10,9 +10,10 @@ locals {
   operations = flatten([
     for endpoint in local.open_api_specification.paths : [
       for endpointType in endpoint : {
-        operationId = endpointType.operationId
+        operationId = endpointType.operationId,
         policy = templatefile("${path.module}/policies/dex_operation_policy.tftpl", {
-          tags = endpointType.tags
+          tags     = endpointType.tags,
+          fhir_url = var.fhir_url
         })
       }
     ]

--- a/infrastructure/services/api_management/output.tf
+++ b/infrastructure/services/api_management/output.tf
@@ -1,3 +1,7 @@
 output "api_management_host_name" {
   value = "${azurerm_api_management.apim.name}.azure-api.net"
 }
+
+output "api_management_system_assigned_identity" {
+  value = azurerm_api_management.apim.identity[0].principal_id
+}

--- a/infrastructure/services/api_management/policies/dex_operation_policy.tftpl
+++ b/infrastructure/services/api_management/policies/dex_operation_policy.tftpl
@@ -1,9 +1,6 @@
 <policies>
     <inbound>
         <base />
-        %{~ if contains(tags, "FhirBackend") ~}
-        <set-backend-service backend-id="fhir-server" />
-        %{~ endif ~}
         <validate-azure-ad-token
             tenant-id="{{TenantId}}"
             header-name="Authorization"
@@ -31,6 +28,10 @@
             </required-claims>
             %{~ endif ~}
         </validate-azure-ad-token>
+        %{~ if contains(tags, "FhirBackend") ~}
+        <set-backend-service backend-id="fhir-server" />
+        <authentication-managed-identity resource="${fhir_url}" />
+        %{~ endif ~}
     </inbound>
     <backend>
         <base />

--- a/infrastructure/services/output.tf
+++ b/infrastructure/services/output.tf
@@ -22,3 +22,7 @@ output "log_analytics_workspace_id" {
 output "web_app_system_assigned_identity" {
   value = azurerm_linux_web_app.web_app.identity[0].principal_id
 }
+
+output "api_management_system_assigned_identity" {
+  value = module.api_management.api_management_system_assigned_identity
+}


### PR DESCRIPTION
This PR updates APIM management's operation policy to use Azure managed identity to authentication with the backend Fhir Service.