### PR TITLE
remove redundant static.

### DIFF
--- a/src/Core/Pds/PdsService.cs
+++ b/src/Core/Pds/PdsService.cs
@@ -226,7 +226,7 @@ public class PdsService(
         return Result.Success();
     }
 
-    private static void EnrichFhirBundleWithPatientsToBeDeleted(List<string> patientsToBeDeleted, Result<Bundle> jsonToBundleResult)
+    private void EnrichFhirBundleWithPatientsToBeDeleted(List<string> patientsToBeDeleted, Result<Bundle> jsonToBundleResult)
     {
         foreach (var patient in patientsToBeDeleted)
         {
@@ -241,7 +241,7 @@ public class PdsService(
         }
     }
 
-    private static string HandleInvalidPDSPatients(Result<string> csvToJsonResult, List<string> patientsToBeDeleted)
+    private string HandleInvalidPDSPatients(Result<string> csvToJsonResult, List<string> patientsToBeDeleted)
     {
         var jsonObject = JObject.Parse(csvToJsonResult.Value);
         var patientsArray = (JArray)jsonObject["patients"]!;


### PR DESCRIPTION
This pull request includes minor changes to the `PdsService.cs` file. The changes involve modifying the access modifiers of two methods, `EnrichFhirBundleWithPatientsToBeDeleted` and `HandleInvalidPDSPatients`, from `static` to instance methods.

* [`src/Core/Pds/PdsService.cs`](diffhunk://#diff-6ee277e4c47c45c8902ef3106c15d9878bd19a53b0c7711b5aed9aa1d8f9eea2L229-R229): The `EnrichFhirBundleWithPatientsToBeDeleted` method was changed from a static method to an instance method. This change allows the method to access instance variables and methods of the `PdsService` class.
* [`src/Core/Pds/PdsService.cs`](diffhunk://#diff-6ee277e4c47c45c8902ef3106c15d9878bd19a53b0c7711b5aed9aa1d8f9eea2L244-R244): Similarly, the `HandleInvalidPDSPatients` method was also changed from a static method to an instance method, enabling it to access instance variables and methods of the `PdsService` class.

