### PR TITLE
Remove dangling static to avoid memory leaks on the heap.

### DIFF
--- a/tests/Integration.Tests/Core/Pds/PdsServiceTests.cs
+++ b/tests/Integration.Tests/Core/Pds/PdsServiceTests.cs
@@ -186,7 +186,7 @@ public class PdsServiceTests : IDisposable
         }
     }
 
-    private static string CreateDummyMeshPatientMessage(string id, string nhsNumber, string matchedNhsNumber, string successErrorCode)
+    private string CreateDummyMeshPatientMessage(string id, string nhsNumber, string matchedNhsNumber, string successErrorCode)
     {
         return string.Join(",",
             new string[]
@@ -270,7 +270,7 @@ public class PdsServiceTests : IDisposable
         return patients;
     }
 
-    private static Patient CreatePatient(string nhsNumber)
+    private Patient CreatePatient(string nhsNumber)
     {
         return new Patient()
         {


### PR DESCRIPTION
This pull request includes changes to the `PdsServiceTests.cs` file in the `tests/Integration.Tests/Core/Pds` directory. The main changes involve modifying two methods, `CreateDummyMeshPatientMessage` and `CreatePatient`, from being static methods to instance methods.

Here are the key changes:

* [`tests/Integration.Tests/Core/Pds/PdsServiceTests.cs`](diffhunk://#diff-d822e660f6d7b5857e409cfcd3c1b12d2631fb8abce1dadaa82c285b3b9d96d8L189-R189): The `CreateDummyMeshPatientMessage` method was changed from a static method to an instance method. 
* [`tests/Integration.Tests/Core/Pds/PdsServiceTests.cs`](diffhunk://#diff-d822e660f6d7b5857e409cfcd3c1b12d2631fb8abce1dadaa82c285b3b9d96d8L273-R273): Similarly, the `CreatePatient` method was also changed from a static method to an instance method..