### PR TITLE
bugfix: Configurable ACR in docker compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       SqlServer__SchemaOptions__AutomaticUpdatesEnabled: "true"
       DataStore: "SqlServer"
       FhirServer__Operations__ConvertData__Enabled: "true"
-      FhirServer__Operations__ConvertData__ContainerRegistryServers__0: ${ACR_NAME}
+      FhirServer__Operations__ConvertData__ContainerRegistryServers__0: "${ACR_NAME:-acrdexoss.azurecr.io}"
       DOTNET_EnableWriteXorExecute: 0
     ports:
       - "8080:8080"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       SqlServer__SchemaOptions__AutomaticUpdatesEnabled: "true"
       DataStore: "SqlServer"
       FhirServer__Operations__ConvertData__Enabled: "true"
-      FhirServer__Operations__ConvertData__ContainerRegistryServers__0: "acrdexoss.azurecr.io"
+      FhirServer__Operations__ConvertData__ContainerRegistryServers__0: ${ACR_NAME}
       DOTNET_EnableWriteXorExecute: 0
     ports:
       - "8080:8080"


### PR DESCRIPTION
Made ACR defined in docker compose configurable from ACR_NAME environment variable.

This allows the environment to use different ACRs when required, such as when running template tests locally.