### PR TITLE
Require hash for pip dependencies

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,5 +29,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install -r ./mkdocs-material-requirements.txt --no-deps
+      - run: pip install -r ./mkdocs-material-requirements.txt --no-deps --require-hashes
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/static-code-analysis.yaml
+++ b/.github/workflows/static-code-analysis.yaml
@@ -38,7 +38,7 @@ jobs:
             python-version: '3.x'
 
       - name: Install pre-commit
-        run: python -m pip install -r ./pre-commit-requirements.txt --no-deps
+        run: python -m pip install -r ./pre-commit-requirements.txt --no-deps --require-hashes
 
       - name: Run pre-commit checks
         run: pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
This PR adds --require-hash to the pip install commands

- [v] Tests
- [ ] Documentation
