### PR TITLE
Update data-init Dockerfile to fix CI

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,7 +1,7 @@
 # v7.0
 FROM mcr.microsoft.com/dotnet/sdk@sha256:64db914029faa026ff41d9284fa3badf039f94292ff1e5ba91e4b4b76e090968
 
-RUN apt update && apt-get install jq curl bash
+RUN apt update && apt-get install -y jq curl bash
 
 RUN dotnet tool install --global uploadfig 	
 


### PR DESCRIPTION
Added flag to apt-get install command, to avoid y/n prompt during installation. The prompt causes docker compose to hang during actions/pipelines.