### PR TITLE
Update health check path in mssql docker image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       SA_PASSWORD: ${SAPASSWORD}
       ACCEPT_EULA: "Y"
     healthcheck:
-      test: [ "CMD", "/opt/mssql-tools/bin/sqlcmd","-U sa -P ${SAPASSWORD} -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" ]
+      test: [ "CMD", "/opt/mssql-tools18/bin/sqlcmd","-U sa -P ${SAPASSWORD} -Q 'SELECT * FROM INFORMATION_SCHEMA.TABLES'" ]
       interval: 10s
       timeout: 10s
       retries: 6

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,7 +54,7 @@ services:
         condition: service_healthy
 
   fhir-sql:
-    image: "mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04"
+    image: "mcr.microsoft.com/mssql/server"
     user: root
     environment:
       SA_PASSWORD: ${SAPASSWORD}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,7 +54,7 @@ services:
         condition: service_healthy
 
   fhir-sql:
-    image: "mcr.microsoft.com/mssql/server"
+    image: "mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04"
     user: root
     environment:
       SA_PASSWORD: ${SAPASSWORD}


### PR DESCRIPTION
Update health check path in mssql docker image to resolve path update introduced in last container image build. 

The issue means docker up reports an error, as the health check fails. 

The issue is causing the CI build to fail.

See https://github.com/microsoft/mssql-docker/issues/892 for further details